### PR TITLE
Main change is on Post Object

### DIFF
--- a/GLOBAL_CONSTANTS.js
+++ b/GLOBAL_CONSTANTS.js
@@ -9,6 +9,8 @@ model.TABLE_NAME.POST = "Post";
 model.TABLE_NAME.TEST = "Test";
 model.TABLE_NAME.TESTSANDRA = "TestSandra";
 
+model.POST_DAO = {};
+model.POST_DAO.SEARCH_RESULT_NUMBER = 10;
 
 /***************************************CONTROL CONSTANTS**********************************************/
 // module.exports.CONTROL = {};
@@ -16,6 +18,16 @@ model.TABLE_NAME.TESTSANDRA = "TestSandra";
 
 /***************************************VIEW CONSTANTS**********************************************/
 // module.exports.VIEW = {};
+
+
+
+
+
+
+
+
+
+
 
 
 module.exports.MODEL = model;

--- a/app/routesHandler.js
+++ b/app/routesHandler.js
@@ -1,5 +1,6 @@
 var PostBO = require('./../control/businessObject/PostBO.js');
 var util = require('./../control/util.js');
+var PostEnum = require('./../control/Enum.js').PostEnum;
 
 var keywordsSearchHandler = function(req, res){
 	var keywordsArray = util.stringToArray(req.body.post.keywords);
@@ -18,7 +19,10 @@ var postFormHandler = function(req, res){
 	var keywordsArray = util.stringToArray(req.body.post.keywords);
 	var description = req.body.post.description;
 	var autherId = req.user._userId;
-	var newPost = new PostBO(title, keywordsArray, description, autherId);
+
+	var byWho = PostEnum[req.body.post.byWho];
+	var createdAt = new Date().getTime();
+	var newPost = new PostBO(title, keywordsArray, description, autherId, byWho, createdAt);
 	newPost.save(function(err){
 		if(err){
 			console.error(err);

--- a/control/Enum.js
+++ b/control/Enum.js
@@ -1,0 +1,22 @@
+var Enum = function() {
+	this._names = [];
+    for (var i in arguments) {
+        this[arguments[i]] = i;
+        this._names[i] = arguments[i];
+    }
+}
+Enum.prototype.getName = function(i){
+	return this._names[i];
+};
+
+Enum.prototype.validate = function(name){
+	if (!this[name]){
+		throw new Error(name + 'doesnt exist');//may need a class for this in Erros.js
+	}
+	return true;
+}
+
+/************************ PostDAO Enum *************************/
+var PostEnum = new Enum('byConsumer', 'byProvider', 'isNotPurchased', 'isPurchased','isNotExpired', 'isExpired');
+
+module.exports.PostEnum = PostEnum;

--- a/control/Errors.js
+++ b/control/Errors.js
@@ -1,0 +1,12 @@
+// Inherit from Error class, this is not supported by all browser but is in chrome
+function EmptyAndSpaceStringError(varName){
+	Error.call(this, varName + 'can not be empty or just spaces.');
+}
+
+EmptyAndSpaceStringError.prototype = Object.create(Error.prototype);
+
+// funciton EnumDoesntExistError(name){
+	
+// }
+
+module.exports.EmptyAndSpaceStringError = EmptyAndSpaceStringError;

--- a/control/businessObject/PostBO.js
+++ b/control/businessObject/PostBO.js
@@ -1,7 +1,10 @@
 var PostDAO = require('./../../model/dao/PostDAO.js');
+var util = require('./../util.js');
+var Errors = require('./../Errors.js');
+var PostEnum = require('./../Enum.js').PostEnum;
 
  /*******************************Dummy Constructor**************************************/ 
-function Post (title, keywordsArray, description, authorId){
+function PostBO (title, keywordsArray, description, authorId, byWho, createdAt){
 	this._title = title;
 	this._keywordsArray = keywordsArray;
 	this._description = description;
@@ -10,23 +13,108 @@ function Post (title, keywordsArray, description, authorId){
 	//this._ongoingMutualAgreementIdArray = ongoingMutualAgreementIdArray;
 	//this._pictureIdArray = pictureIdArray;
 	//this._creationDate = TIMESTAMP...
-	//this._creationDate = 0;
 	//this._googlePlaceId = googlePlaceId;
 	//this._rating = rating;
 	//this._totalNumReviews = totalNumReviews;
+	this._byWho = byWho;
+	this._isPurchased = PostEnum.isNotPurchased;
+	this._isExpired = PostEnum.isNotExpired;
+	this._createdAt = createdAt;
 }
 
 /*******************************Static Method**************************************/
-Post.findPostsByKeywordsArray = function(keywordsArray, callback){
+PostBO.findPostsByKeywordsArray = function(keywordsArray, callback){
 	PostDAO.findPostsByKeywordsArray(keywordsArray, callback);
 }
 
 /*******************************Instance Method**************************************/
-Post.prototype.save = function(callback){
-	var newPost = PostDAO.create(this._title, this._keywordsArray, this._description, this._authorId);
-	newPost.save(function(err){
+PostBO.prototype.save = function(callback){
+	var newPostDAO = PostDAO.create(this.getTitle(), this.getKeywordsArray(), this.getDescription(), this.getAuthorId(), this.getByWho(), 
+		this.getIsPurchased(), this.getIsExpired(), this.getCreatedAt());
+	newPostDAO.save(function(err){
 		callback(err);
 	});
 }
 
-module.exports = Post;
+/*******************************Dummy Getters**************************************/
+PostBO.prototype.getTitle = function(){
+	return this._title;
+};
+
+PostBO.prototype.getKeywordsArray = function(){
+	return this._keywordsArray;
+};
+
+PostBO.prototype.getDescription = function(){
+	return this._description;
+};
+
+PostBO.prototype.getAuthorId = function(){
+	return this._authorId;
+};
+
+PostBO.prototype.getByWho = function(){
+	return this._byWho;
+};
+
+PostBO.prototype.getIsPurchased = function(){
+	return this._isPurchased;
+};
+
+PostBO.prototype.getIsExpired = function(){
+	return this._isExpired;
+};
+
+PostBO.prototype.getCreatedAt = function(){
+	return this._createdAt;
+};
+/*******************************Setters**************************************/
+PostBO.prototype.setTitle = function(newTitle){
+	if(util.validateEmptyAndSpaceString(newTitle)){
+		this._title = newTitle;
+	} else {
+		throw new Errors.EmptyAndSpaceStringError('title');
+	}
+};
+
+PostBO.prototype.setKeywordsArray = function(newKeywordsArray){
+	this._keywordsArray = newKeywordsArray.splice();
+};
+
+PostBO.prototype.setDescription = function(newDescription){
+	if(util.validateEmptyAndSpaceString(newDescription)){
+		this._description = newDescription;
+	} else {
+		throw new Errors.EmptyAndSpaceStringError('description');
+	}
+};
+
+PostBO.prototype.setAuthorId = function(newAuthorId){
+	if(util.validateEmptyAndSpaceString(newAuthorId)){
+		this._authorId = newAuthorId;
+	} else {
+		throw new Errors.EmptyAndSpaceStringError('authorId');
+	}
+};
+
+PostBO.prototype.setByWho = function(newByWho){
+	PostEnum.validate(newByWho);
+	this._newByWho = PostEnum[newByWho];
+};
+
+PostBO.prototype.setIsPurchased = function(newIsPurchased){
+	PostEnum.validate(newIsPurchased);
+	this._isPurchased = PostEnum[newIsPurchased];
+};
+
+PostBO.prototype.setIsExpired = function(newIsExpired){
+	PostEnum.validate(newIsExpired);
+	this._isExpired = PostEnum[newIsExpired];
+};
+
+PostBO.prototype.set = function(newCreatedAt){
+	this._createdAt = newCreatedAt;
+};
+
+
+module.exports = PostBO;

--- a/control/businessObject/UserBO.js
+++ b/control/businessObject/UserBO.js
@@ -1,8 +1,8 @@
 var UserDAO = require('./../../model/dao/UserDAO.js');
-var UserConverter = require('./../../model/Converter.js');
+var Converter = require('./../../model/Converter.js');
 
  /*******************************Dummy Constructor**************************************/ 
-function User (userId, password){
+function UserBO (userId, password){
 	this._userId = userId;
 	this._password = password;
 	//this._userName = userName;
@@ -14,7 +14,7 @@ function User (userId, password){
 // find if user with userId exists in the database
 // callback(err, valid);
 // valid is a bool denoting whether userId already exists
-User.validateId = function (userId, callback) {
+UserBO.validateId = function (userId, callback) {
 	UserDAO.findById(userId, function (err, user) {
 		if (err) {
 			callback(err);
@@ -27,33 +27,33 @@ User.validateId = function (userId, callback) {
 			if (user) {
 				valid = true;
 			}
-
+			
 			callback(err, valid);
 		}
 	});
 }
 
 // validate user login by checking userId and password combination
-// callback(err, validUser);
-// validUser is null when combination is incorrect
-// validUser is an equivalent UserBO object to the valid UserDAO found
-User.validateIdPw = function (userId, password, callback) {
+// callback(err, validUserBO);
+// validUserBO is null when combination is incorrect
+// validUserBO is an equivalent UserBOBO object to the valid UserDAO found
+UserBO.validateIdPw = function (userId, password, callback) {
 	UserDAO.findById(userId, function (err, user) {
 		if (err) {
 			callback(err);
 		} else {
-			// initialize validUser to null
-			// invalid combination will keep validUser as null
-			var validUser = null;
+			// initialize validUserBO to null
+			// invalid combination will keep validUserBO as null
+			var validUserBO = null;
 
 			// if the userId and password combination is valid,
-			// make validUser an equivalent UserBO object to the found UserDAO object
+			// make validUserBO an equivalent UserBOBO object to the found UserDAO object
 			if (password === user.password) {
-				validUser = new User(user._id, user.password);
+				validUserBO = new UserBO(user._id, user.password);
 			}
 
-			// call back with error and validUser
-			callback(err, validUser);
+			// call back with error and validUserBO
+			callback(err, validUserBO);
 		}
 	});
 }
@@ -62,11 +62,22 @@ User.validateIdPw = function (userId, password, callback) {
 
 // insert user to the database
 // callback(err);
-User.prototype.save = function (callback) {
-	var newUserDAO = UserConverter.convertFromUserBOtoUserDAO(this);
+UserBO.prototype.save = function (callback) {
+	var newUserDAO = Converter.convertFromUserBOtoUserDAO(this);
 	newUserDAO.save(function (err){
 		callback(err);
 	});
 }
 
-module.exports = User;
+/*******************************Dummy Getters**************************************/
+UserBO.prototype.getUserId = function(){
+	return this._userId;
+};
+
+UserBO.prototype.getPassword = function(){
+	return this._password;
+};
+
+// We also need setters for these fields, they are private!
+
+module.exports = UserBO;

--- a/control/util.js
+++ b/control/util.js
@@ -2,4 +2,9 @@ var stringToArray = function(s){
 	return s.split(" ").filter(Boolean);
 }
 
+var validateEmptyAndSpaceString = function(s){
+	return s && s.trim();
+}
+
 module.exports.stringToArray = stringToArray;
+module.exports.validateEmptyAndSpaceString = validateEmptyAndSpaceString;

--- a/model/Converter.js
+++ b/model/Converter.js
@@ -4,22 +4,25 @@ var UserBO = require('./../control/businessObject/UserBO');
 var PostBO = require('./../control/businessObject/PostBO');
 
 var convertFromUserBOtoUserDAO = function(userBO){
-	var userDAO = UserDAO.create(userBO._userId, userBO._password);
+	var userDAO = UserDAO.create(userBO.getUserId(), userBO.getPassword());
 	return userDAO;
 }
 
 var convertFromUserDAOtoUserBO = function(userDAO){
-	var userBO = new UserBO(userDAO._id, userDAO.password);
+	var userBO = new UserBO(userDAO.id, userDAO.password);
 	return userBO;
 }
 
 var convertFromPostBOtoPostDAO = function(postBO){
-	var postDAO = PostDAO.create(postBO._title, postBO._keywordsArray, postBO._description, postBO._authorId);
+	var postDAO = PostDAO.create(postBO.getTitle(), postBO.getKeywordsArray(), postBO.getDescription(), postBO.getAuthorId(), postBO.getByWho(), postBO.getIsPurchased(), postBO.getIsExpired(), postBO.getgetCreatedAt());
 	return postDAO;
 }
 
 var convertFromPostDAOtoPostBO = function(postDAO){
-	var postBO = new PostBO(postBO._title, postBO._keywordsArray, postBO._description, postBO._authorId);
+	var postBO = new PostBO(postDAO.title, postDAO.keywordsArray, postDAO.description, postDAO.authorId, postDAO.byWho, postDAO.createdAt);
+	 // set postDAO.isPurchased, postDAO.isExpired
+	postBO.setIsPurchased(postDAO.isPurchased);
+	postBO.setIsExpired(postDAO.isExpired);
 	return postBO;
 }
 

--- a/model/dao/PostDAO.js
+++ b/model/dao/PostDAO.js
@@ -1,5 +1,6 @@
 var mongoose = require('mongoose');
 var GLOBAL_CONSTANTS = require('./../../GLOBAL_CONSTANTS.js');
+var util = require('./../../control/util.js');
 
 /************************ Table Schema *************************/
 var postDAOSchema = new mongoose.Schema({
@@ -20,31 +21,47 @@ var postDAOSchema = new mongoose.Schema({
 		trim: true,
 		required: true
 	},
+	// The following three are for compound indexs, so I have to make sure they are numbers
+	byWho : {
+		type: Number, // see util.Enum constructor
+		required: true
+	},
+	isPurchased : {
+		type: Number,
+		required: true
+	},
+	isExpired : {
+		type: Number,
+		required: true
+	},
 	//expiryDate : {type: int, required: true},
 	//commentIdArray : {type: Array<String>, required: true},
 	//ongoingMutualAgreementIdArray : {type: Array<String>, required: true},
 	//pictureIdArray : {type: Array<String>, required: true},
 	//googlePlaceId : {type: Array<String}, required: true},
-	creationDate : {
-		type: Date, 
-		default: Date.now
+	createdAt : {
+		type: Number, 
+		required: true
 	},
 	//rating : {type: float, required: true},
 	/*totalNumReviews : {type: int, required: true},*/ 
 	}, {collection: GLOBAL_CONSTANTS.MODEL.TABLE_NAME.POST});
 
 /************************ Static Methods *************************/
-postDAOSchema.statics.create = function(title, keywordsArray, description, authorId){
+postDAOSchema.statics.create = function(title, keywordsArray, description, authorId, byWho, isPurchased, isExpired, createdAt){
 	return new PostDAO({
 		title: title,
 		keywordsArray: keywordsArray,
 		description: description,
-		authorId: authorId
+		authorId: authorId,
+		byWho: byWho,
+		isPurchased: isPurchased, 
+		isExpired: isExpired,
 		//expiryDate: expiryDate,
 		//ongoingMutualAgreementIdArray: ongoingMutualAgreementIdArray,
 		//pictureIdArray: pictureIdArray,
 		//googlePlaceId: googlePlaceId,
-		// creationDate: creationDate, (This is not needed, cuz creationDate is self defined)  
+		createdAt: createdAt
 		//rating: rating,
 		//totalNumReviews: totalNumReviews
 	});
@@ -53,7 +70,7 @@ postDAOSchema.statics.create = function(title, keywordsArray, description, autho
 postDAOSchema.statics.findPostsByKeywordsArray = function(keywordsArray, callback){
 	this.find({keywordsArray: {$in: keywordsArray}}, function(err, docs){
 		callback(err, docs);
-	}).limit(10);
+	}).limit(GLOBAL_CONSTANTS.MODEL.POST_DAO.SEARCH_RESULT_NUMBER);
 }
 
 /************************ Instance Methods *************************/

--- a/views/pages/home.ejs
+++ b/views/pages/home.ejs
@@ -123,7 +123,17 @@
                   <textarea class="form-control" id="summary" name="post[description]" placeholder="Please enter your summary here..." rows="5"></textarea>
                 </div>
               </div>
-      
+
+              <!-- Radio input -->
+              <div class="form-group">
+                <label class="radio-inline">
+                  <input name="post[byWho]" id="byConsumerRadio" value="byConsumer" type="radio"> Looking for this service!
+                </label>
+                <label class="radio-inline">
+                  <input name="post[byWho]" id="byProviderRadio" value="byProvider" type="radio" checked=""> Providing this service!
+                </label>
+              </div>
+
               <!-- Form actions -->
               <div class="form-group">
                 <div class="col-md-12 text-right">


### PR DESCRIPTION
I added:

- isPurchased, isExpired, byWho Enum into Post object. (Enum is like a 1:1 constant map). Since Mongo only supports compound index for numbers I have to somehow numberize the concept of "byWho". In this case "byProvider" is assigned with number 1, and "byConsumer" is assigned with number 2. So when we do the compound search in mongoose. Really it looks like byWho: $eq 1, isPurchased: $eq 3, isExpired: $eq4. Something like that

- Having above implementation. Our original 6 Post Table design can be reduced into 1 giant Post table

- I also made a new Attribute in Post which is createAt. [IMPORTANT]Even if mongoose supply the default date function to set its vale when we insert the document. But this is getting annoying and confusing when we are converting between PostBO and PostDAO. So I made it as a required attribute

- I noticed that BO object fields are all meant to be private. But I noticed that we aren't do it properly. So i just roughly added getters and setters for PostBO, we may need more validation for the setters. Plz continue the similar work for UserBO [TO DO]
